### PR TITLE
python 2+3 dual compatibility

### DIFF
--- a/emopt/__init__.py
+++ b/emopt/__init__.py
@@ -1,4 +1,4 @@
-import adjoint_method, fdfd, fdtd, fomutils, grid, io, misc, modes, optimizer, \
+from . import adjoint_method, fdfd, fdtd, fomutils, grid, io, misc, modes, optimizer, \
        simulation, geometry
 
 __all__ = ["adjoint_method", "fdfd", "fomutils", "grid", "io", "misc", "modes",

--- a/emopt/adjoint_method.py
+++ b/emopt/adjoint_method.py
@@ -186,11 +186,12 @@ References
 .. [1] A. Michaels, E. Yablonovitch, "Gradient-Based Inverse Electromagnetic Design Using Continuously-Smoothed Boundaries", arXiv:1705.07188, 2017
 """
 
-import fdfd
-import fdtd
-from misc import info_message, warning_message, error_message, RANK, \
+from __future__ import division, print_function, absolute_import
+from . import fdfd
+from . import fdtd
+from .misc import info_message, warning_message, error_message, RANK, \
 NOT_PARALLEL, run_on_master, N_PROC, COMM
-import fomutils
+from . import fomutils
 
 import numpy as np
 from math import pi
@@ -539,7 +540,7 @@ class AdjointMethod(object):
             grad_full = np.zeros(N_PROC, dtype=np.double)
 
         gradient = np.zeros(lenp)
-        for i in xrange(lenp):
+        for i in range(lenp):
             p0 = params[i]
             ub = update_boxes[i]
 
@@ -1047,9 +1048,9 @@ class AdjointMethodFM(AdjointMethod):
             grad_full = np.zeros(sim.nunks, dtype=np.double)
 
         gradient = np.zeros(lenp)
-        for i in xrange(lenp):
+        for i in range(lenp):
             #if(NOT_PARALLEL):
-            #    print i
+            #    print(i)
             p0 = params[i]
             ub = update_boxes[i]
 

--- a/emopt/defs.py
+++ b/emopt/defs.py
@@ -1,5 +1,6 @@
 """Define some useful definitions for emopt.
 """
+from __future__ import division, print_function, absolute_import
 
 __author__ = "Andrew Michaels"
 __license__ = "GPL License, Version 3.0"

--- a/emopt/fdfd.py
+++ b/emopt/fdfd.py
@@ -56,19 +56,20 @@ correctly-sized zeroed numpy array on the non-master nodes.
 2. Reimplement the set_source function with Domain support.  This will be
 necessary in 3D when the total grid size is very large.
 """
+from __future__ import division, print_function, absolute_import
 
 # Initialize petsc first
 import petsc4py
 import sys
 petsc4py.init(sys.argv)
 
-from misc import info_message, warning_message, error_message, RANK, \
+from .misc import info_message, warning_message, error_message, RANK, \
 NOT_PARALLEL, run_on_master, MathDummy, DomainCoordinates, COMM
-from defs import FieldComponent, SourceComponent
-import modes
-from simulation import MaxwellSolver
+from .defs import FieldComponent, SourceComponent
+from . import modes
+from .simulation import MaxwellSolver
 
-from grid import row_wise_A_update
+from .grid import row_wise_A_update
 
 import numpy as np
 from math import pi
@@ -742,7 +743,7 @@ class FDFD_TE(FDFD):
         if(self.verbose and NOT_PARALLEL):
             info_message('Building system matrix...')
 
-        for i in xrange(self.ib, self.ie):
+        for i in range(self.ib, self.ie):
 
             ig = int(i/Nc)
             component = int(i - Nc*ig)
@@ -934,7 +935,7 @@ class FDFD_TE(FDFD):
         A_update = self.A_diag_update
 
         #TODO: Use setDiagonal
-        for i in xrange(self.ib, self.ie):
+        for i in range(self.ib, self.ie):
             A[i,i] = A_update[i-self.ib]
 
         # communicate off-processor values and setup internal data structures for
@@ -2342,7 +2343,7 @@ class FDFD_3D(FDFD):
         component = 0
         x = 0; y = 0; z = 0
         Nc = 6 # 6 field components
-        for i in xrange(ib, ie):
+        for i in range(ib, ie):
 
             ig = int(i/Nc)
             component = int(i - 6*ig)
@@ -2683,7 +2684,7 @@ class FDFD_3D(FDFD):
 
         alpha = 1.0/7.0
 
-        for i in xrange(ib,ie):
+        for i in range(ib,ie):
             ig = int(i/bsize)
             comp = int(i - bsize*ig)
 
@@ -2854,7 +2855,7 @@ class FDFD_3D(FDFD):
         component = 0
         x = 0; y = 0; z = 0
         Nc = 6 # 6 field components
-        for i in xrange(ib, ie):
+        for i in range(ib, ie):
 
             ig = int(i/Nc)
             component = int(i - 6*ig)
@@ -3081,9 +3082,9 @@ class FDFD_3D(FDFD):
         elif(component == FieldComponent.Hy): c = 4
         elif(component == FieldComponent.Hz): c = 5
 
-        for z in xrange(i1, i2):
-            for y in xrange(j1, j2):
-                for x in xrange(k1, k2):
+        for z in range(i1, i2):
+            for y in range(j1, j2):
+                for x in range(k1, k2):
                     index = Nc*(z*NxNy+y*Nx+x)+c
 
                     if(index >= ib and index < ie):
@@ -3339,9 +3340,9 @@ class FDFD_3D(FDFD):
         elif(component == FieldComponent.Hy): c = 4
         elif(component == FieldComponent.Hz): c = 5
 
-        for z in xrange(i1, i2):
-            for y in xrange(j1, j2):
-                for x in xrange(k1, k2):
+        for z in range(i1, i2):
+            for y in range(j1, j2):
+                for x in range(k1, k2):
                     index = Nc*(z*NxNy+y*Nx+x)+c
 
                     if(index >= ib and index < ie):
@@ -3549,7 +3550,7 @@ class FDFD_3D(FDFD):
         if(ymax > Ny-1): ymax = Ny-1
         if(zmax > Nz-1): zmax = Nz-1
 
-        #print xmin, xmin-k1, ymin, ymin-j1, zmin, zmin-i1
+        #print(xmin, xmin-k1, ymin, ymin-j1, zmin, zmin-i1)
 
         Jx = src[0]
         Jy = src[1]
@@ -3665,7 +3666,7 @@ class FDFD_3D(FDFD):
 
         if(NOT_PARALLEL and self._bc[0] != 'E' and self._bc[0] != 'H'):
             Px = -0.5*dy*dz*np.sum(np.real(Ey*np.conj(Hz)-Ez*np.conj(Hy)))
-            #print Px
+            #print(Px)
             Psrc += Px
         del Ey; del Ez; del Hy; del Hz
 
@@ -3677,7 +3678,7 @@ class FDFD_3D(FDFD):
 
         if(NOT_PARALLEL):
             Px = 0.5*dy*dz*np.sum(np.real(Ey*np.conj(Hz)-Ez*np.conj(Hy)))
-            #print Px
+            #print(Px)
             Psrc += Px
         del Ey; del Ez; del Hy; del Hz
 
@@ -3689,7 +3690,7 @@ class FDFD_3D(FDFD):
 
         if(NOT_PARALLEL and self._bc[1] != 'E' and self._bc[1] != 'H'):
             Py = 0.5*dy*dz*np.sum(np.real(Ex*np.conj(Hz)-Ez*np.conj(Hx)))
-            #print Py
+            #print(Py)
             Psrc += Py
         del Ex; del Ez; del Hx; del Hz
 
@@ -3701,7 +3702,7 @@ class FDFD_3D(FDFD):
 
         if(NOT_PARALLEL):
             Py = -0.5*dy*dz*np.sum(np.real(Ex*np.conj(Hz)-Ez*np.conj(Hx)))
-            #print Py
+            #print(Py)
             Psrc += Py
         del Ex; del Ez; del Hx; del Hz
 
@@ -3713,7 +3714,7 @@ class FDFD_3D(FDFD):
 
         if(NOT_PARALLEL and self._bc[2] != 'E' and self._bc[2] != 'H'):
             Pz = -0.5*dy*dz*np.sum(np.real(Ex*np.conj(Hy)-Ey*np.conj(Hx)))
-            #print Pz
+            #print(Pz)
             Psrc += Pz
         del Ex; del Ey; del Hx; del Hy
 
@@ -3725,7 +3726,7 @@ class FDFD_3D(FDFD):
 
         if(NOT_PARALLEL):
             Pz = 0.5*dy*dz*np.sum(np.real(Ex*np.conj(Hy)-Ey*np.conj(Hx)))
-            #print Pz
+            #print(Pz)
             Psrc += Pz
         del Ex; del Ey; del Hx; del Hy
 

--- a/emopt/fdtd.py
+++ b/emopt/fdtd.py
@@ -18,13 +18,13 @@ considerably less RAM, making it useful for optimizing much larger devices at mu
 higher resolutions.
 
 """
-
-from simulation import MaxwellSolver
-from defs import FieldComponent
-from misc import DomainCoordinates, RANK, MathDummy, NOT_PARALLEL, COMM, \
+from __future__ import division, print_function, absolute_import
+from .simulation import MaxwellSolver
+from .defs import FieldComponent
+from .misc import DomainCoordinates, RANK, MathDummy, NOT_PARALLEL, COMM, \
 info_message, warning_message, N_PROC, run_on_master
-from fdtd_ctypes import libFDTD
-from modes import ModeFullVector
+from .fdtd_ctypes import libFDTD
+from .modes import ModeFullVector
 import petsc4py
 import sys
 petsc4py.init(sys.argv)
@@ -1123,7 +1123,7 @@ class FDTD(MaxwellSolver):
 
         # perform a couple more iterations to get a second time point
         n0 = n
-        for n in xrange(Tn):
+        for n in range(Tn):
             libFDTD.FDTD_update_H(self._libfdtd, n+n0, (n+n0)*dt)
 
             # Note: da.localToLocal seems to have the same performance?
@@ -1140,7 +1140,7 @@ class FDTD(MaxwellSolver):
 
         libFDTD.FDTD_capture_t1_fields(self._libfdtd)
 
-        for n in xrange(Tn):
+        for n in range(Tn):
             libFDTD.FDTD_update_H(self._libfdtd, n+n0+Tn, (n+n0+Tn)*dt)
 
             # Note: da.localToLocal seems to have the same performance?
@@ -1560,7 +1560,7 @@ class FDTD(MaxwellSolver):
 
         if(NOT_PARALLEL and self._bc[0] != 'E' and self._bc[0] != 'H'):
             Px = -0.5*dy*dz*np.sum(np.real(Ey*np.conj(Hz)-Ez*np.conj(Hy)))
-            #print Px
+            #print(Px)
             Psrc += Px
         del Ey; del Ez; del Hy; del Hz
 
@@ -1572,7 +1572,7 @@ class FDTD(MaxwellSolver):
 
         if(NOT_PARALLEL):
             Px = 0.5*dy*dz*np.sum(np.real(Ey*np.conj(Hz)-Ez*np.conj(Hy)))
-            #print Px
+            #print(Px)
             Psrc += Px
         del Ey; del Ez; del Hy; del Hz
 
@@ -1584,7 +1584,7 @@ class FDTD(MaxwellSolver):
 
         if(NOT_PARALLEL and self._bc[1] != 'E' and self._bc[1] != 'H'):
             Py = 0.5*dx*dz*np.sum(np.real(Ex*np.conj(Hz)-Ez*np.conj(Hx)))
-            #print Py
+            #print(Py)
             Psrc += Py
         del Ex; del Ez; del Hx; del Hz
 
@@ -1596,7 +1596,7 @@ class FDTD(MaxwellSolver):
 
         if(NOT_PARALLEL):
             Py = -0.5*dx*dz*np.sum(np.real(Ex*np.conj(Hz)-Ez*np.conj(Hx)))
-            #print Py
+            #print(Py)
             Psrc += Py
         del Ex; del Ez; del Hx; del Hz
 
@@ -1608,7 +1608,7 @@ class FDTD(MaxwellSolver):
 
         if(NOT_PARALLEL and self._bc[2] != 'E' and self._bc[2] != 'H'):
             Pz = -0.5*dx*dy*np.sum(np.real(Ex*np.conj(Hy)-Ey*np.conj(Hx)))
-            #print Pz
+            #print(Pz)
             Psrc += Pz
         del Ex; del Ey; del Hx; del Hy
 
@@ -1620,7 +1620,7 @@ class FDTD(MaxwellSolver):
 
         if(NOT_PARALLEL):
             Pz = 0.5*dx*dy*np.sum(np.real(Ex*np.conj(Hy)-Ey*np.conj(Hx)))
-            #print Pz
+            #print(Pz)
             Psrc += Pz
         del Ex; del Ey; del Hx; del Hy
 

--- a/emopt/fdtd.py
+++ b/emopt/fdtd.py
@@ -41,6 +41,13 @@ __version__ = "0.4"
 __maintainer__ = "Andrew Michaels"
 __status__ = "development"
 
+def to_bytes(s):
+    """Convert a string s to bytes, if it isn't already.
+    (So this does nothing in Python 2.)""" 
+    if type(s) is bytes:
+        return s
+    return s.encode()
+
 class SourceArray(object):
     """A container for source arrays and its associated parameters.
 
@@ -384,7 +391,7 @@ class FDTD(MaxwellSolver):
 
         # default boundary conditions = PEC
         self._bc = ['0', '0', '0']
-        libFDTD.FDTD_set_bc(self._libfdtd, ''.join(self._bc))
+        libFDTD.FDTD_set_bc(self._libfdtd, to_bytes(''.join(self._bc)))
 
         # make room for eps and mu
         self._eps = None
@@ -538,7 +545,7 @@ class FDTD(MaxwellSolver):
                                           'implemented')
 
         self._bc = list(newbc)
-        libFDTD.FDTD_set_bc(self._libfdtd, ''.join(self._bc))
+        libFDTD.FDTD_set_bc(self._libfdtd, to_bytes(''.join(self._bc)))
 
     @property
     def w_pml(self):

--- a/emopt/fdtd_ctypes.py
+++ b/emopt/fdtd_ctypes.py
@@ -1,5 +1,6 @@
 """Provides a ctypes interface between C++ FDTD library and python."""
 
+from __future__ import division, print_function, absolute_import
 from ctypes import *
 import os
 import numpy as np

--- a/emopt/fomutils.py
+++ b/emopt/fomutils.py
@@ -1,9 +1,10 @@
 """
 Common functions useful for calculating figures of merit and their derivatives.
 """
-import fdfd, misc
-from misc import NOT_PARALLEL
-from defs import FieldComponent
+from __future__ import division, print_function, absolute_import
+from . import fdfd, misc
+from .misc import NOT_PARALLEL
+from .defs import FieldComponent
 import numpy as np
 
 __author__ = "Andrew Michaels"

--- a/emopt/geometry.py
+++ b/emopt/geometry.py
@@ -1,7 +1,8 @@
+from __future__ import division, print_function, absolute_import
 import numpy as np
 import scipy
 from math import pi
-from misc import warning_message, NOT_PARALLEL
+from .misc import warning_message, NOT_PARALLEL
 
 def fillet(x, y, R, make_round=None, points_per_90=10, equal_thresh=1e-8,
            ignore_roc_lim=False):

--- a/emopt/grid.py
+++ b/emopt/grid.py
@@ -21,13 +21,14 @@ boundaries using polygons and then computing the smoothed grid by applying a
 series of boolean subtraction operations (in c++).
 """
 
-from grid_ctypes import libGrid
+from __future__ import division, print_function, absolute_import
+from .grid_ctypes import libGrid
 import numpy as np
 import scipy
 from ctypes import c_int, c_double
 
-from misc import DomainCoordinates
-from misc import warning_message
+from .misc import DomainCoordinates
+from .misc import warning_message
 
 __author__ = "Andrew Michaels"
 __license__ = "GPL License, Version 3.0"

--- a/emopt/grid_ctypes.py
+++ b/emopt/grid_ctypes.py
@@ -1,5 +1,6 @@
 """Define an interface for accessing the grid library written in c++."""
 
+from __future__ import division, print_function, absolute_import
 from ctypes import *
 import os
 import numpy as np

--- a/emopt/io.py
+++ b/emopt/io.py
@@ -173,7 +173,7 @@ def plot_iteration(field, structure, W, H, foms, fname='', layout='auto',
 
     ax_foms.set_xlabel('Iteration', fontsize=12)
     ax_foms.set_ylabel('Figure of Merit', fontsize=12)
-    ax_foms.legend(foms.keys(), loc=4)
+    ax_foms.legend(list(foms.keys()), loc=4)
     ax_foms.grid(True, linewidth=0.5)
 
     # general tick properties

--- a/emopt/io.py
+++ b/emopt/io.py
@@ -1,8 +1,9 @@
 """Various functions associated loading and saving files.
 """
 
-from misc import run_on_master, warning_message
-from grid import Polygon
+from __future__ import division, print_function, absolute_import
+from .misc import run_on_master, warning_message
+from .grid import Polygon
 import numpy as np
 
 __author__ = "Andrew Michaels"

--- a/emopt/misc.py
+++ b/emopt/misc.py
@@ -75,9 +75,12 @@ class EMOptWarning(RuntimeWarning):
     pass
 
 @run_on_master
-def _warning_message(message, category=UserWarning, filename='', lineno=-1):
+def _warning_message(message, category=UserWarning, filename='', lineno=-1,
+                     file=None, line=None):
     # Override python's warning message by adding a colored [WARNING] flag in
     # front to make it more noticeable.
+    # file & line arguments are ignored, but are needed to match the
+    # signature of warnings.showwarning.
     if(category == EMOptWarning):
         print(u'\u001b[43;1m[WARNING]\u001b[0m %s' % (message))
     else:

--- a/emopt/misc.py
+++ b/emopt/misc.py
@@ -1,6 +1,7 @@
 """Miscellanious functions useful for simulation and optimization.
 """
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy import interpolate
 import os

--- a/emopt/modes.py
+++ b/emopt/modes.py
@@ -38,15 +38,16 @@ References
 Modesolver for Anisotropic Dielectric Waveguides", J. Lightwave Technol. 26(11),
 1423-1431, (2008).
 """
+from __future__ import division, print_function, absolute_import
 # Initialize petsc first
 import sys, slepc4py
 slepc4py.init(sys.argv)
 
-from defs import FieldComponent
-from misc import info_message, warning_message, error_message, \
+from .defs import FieldComponent
+from .misc import info_message, warning_message, error_message, \
 NOT_PARALLEL, run_on_master, MathDummy
 
-import grid
+from . import grid
 
 from abc import ABCMeta, abstractmethod
 from petsc4py import PETSc
@@ -406,7 +407,7 @@ class ModeTE(ModeSolver):
         eps = self.eps
         N = self._N
 
-        for I in xrange(self.ib, self.ie):
+        for I in range(self.ib, self.ie):
 
             # (stuff) = n_x B H_y
             if(I < N):
@@ -485,7 +486,7 @@ class ModeTE(ModeSolver):
 
         # Define B. It contains ones on the first and last third of the
         # diagonals
-        for i in xrange(self.ib, self.ie):
+        for i in range(self.ib, self.ie):
             if(i < N):
                 B[i,i+2*N] = -1j*self._dir # _dir=1 corresponds to exp(-ikx)
             elif(i < 2*N):
@@ -1336,7 +1337,7 @@ class ModeFullVector(ModeSolver):
                 get_mu_y = lambda x,y : mu.get_value(k0+x,j0+y,i0)
                 get_mu_z = lambda x,y : mu.get_value(k0+x,j0+y,i0)
 
-        for I in xrange(self.ib, self.ie):
+        for I in range(self.ib, self.ie):
             A[I,I] = 0.0
             B[I,I] = 0.0
 

--- a/emopt/optimizer.py
+++ b/emopt/optimizer.py
@@ -39,8 +39,9 @@ The :class:`.Optimizer` is used approximately as follows:
     opt.run()
 """
 
-import fdfd # this needs to come first
-from misc import info_message, warning_message, error_message, RANK, \
+from __future__ import division, print_function, absolute_import
+from . import fdfd # this needs to come first
+from .misc import info_message, warning_message, error_message, RANK, \
 NOT_PARALLEL, run_on_master, COMM
 
 import numpy as np

--- a/emopt/simulation.py
+++ b/emopt/simulation.py
@@ -7,6 +7,7 @@ all Maxwell solvers must implement. This allows us to standard functionality
 and ensure compatibility between modules.
 """
 
+from __future__ import division, print_function, absolute_import
 from abc import ABCMeta, abstractmethod
 
 __author__ = "Andrew Michaels"

--- a/examples/MMI_splitter_3D/mmi_1x2_splitter_3D.py
+++ b/examples/MMI_splitter_3D/mmi_1x2_splitter_3D.py
@@ -38,6 +38,7 @@ terminates when this value drops below the specified rtol (which defaults to
 1e-6)
 """
 
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL, run_on_master
 from emopt.adjoint_method import AdjointMethod

--- a/examples/MMI_splitter_3D/mmi_1x2_splitter_3D_fdtd.py
+++ b/examples/MMI_splitter_3D/mmi_1x2_splitter_3D_fdtd.py
@@ -34,6 +34,7 @@ much larger/higher resolution problems. In this example, we use a finer grid
 spacing than the FDFD example.
 """
 
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL, run_on_master
 from emopt.adjoint_method import AdjointMethod

--- a/examples/Silicon_Grating_Coupler/gc_opt.py
+++ b/examples/Silicon_Grating_Coupler/gc_opt.py
@@ -33,6 +33,7 @@ in the command line which will run the optimization using 16 cores on the curren
 machine.
 
 """
+from __future__ import division, print_function, absolute_import
 # We need to import a lot of things from emopt
 import emopt
 from emopt.misc import NOT_PARALLEL

--- a/examples/Silicon_Grating_Coupler/gc_opt_constrained.py
+++ b/examples/Silicon_Grating_Coupler/gc_opt_constrained.py
@@ -43,6 +43,7 @@ in the command line which will run the optimization using 16 cores on the curren
 machine.
 
 """
+from __future__ import division, print_function, absolute_import
 # We need to import a lot of things from emopt
 import emopt
 from emopt.misc import NOT_PARALLEL
@@ -132,7 +133,7 @@ class SiliconGratingAM(AdjointMethodPNF):
         This generally works pretty well, as well.
         """
         coeffs = params
-        N_coeffs = (len(coeffs) - 3) / 4
+        N_coeffs = int((len(coeffs) - 3) / 4)
 
         h_etch = params[-3]
         x0 = self.w_in + params[-2]

--- a/examples/Silicon_Grating_Coupler/mode_data.py
+++ b/examples/Silicon_Grating_Coupler/mode_data.py
@@ -7,6 +7,7 @@
     Generate electric and magnetic field for Gaussian beam.
 """
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from math import pi
 import scipy

--- a/examples/Silicon_Grating_Coupler_2L/mode_data.py
+++ b/examples/Silicon_Grating_Coupler_2L/mode_data.py
@@ -7,6 +7,7 @@
     Generate electric and magnetic field for Gaussian beam.
 """
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from math import pi
 import scipy

--- a/examples/Silicon_Grating_Coupler_2L/sg2l_opt.py
+++ b/examples/Silicon_Grating_Coupler_2L/sg2l_opt.py
@@ -33,6 +33,7 @@ in the command line which will run the optimization using 16 cores on the curren
 machine.
 
 """
+from __future__ import division, print_function, absolute_import
 # We need to import a lot of things from emopt
 import emopt
 from emopt.misc import NOT_PARALLEL
@@ -118,7 +119,7 @@ class SiliconGrating2LAM(AdjointMethodPNF):
         x0_top = self.w_in + params[-2]
         x0_bot = self.w_in + params[-1]
         coeffs = params
-        N_coeffs = (len(coeffs) - 2) / 8
+        N_coeffs = int((len(coeffs) - 2) / 8)
 
         # compute the periods and duty factors using a Fourier series
         fseries = lambda coeffs : coeffs[0] + np.sum([coeffs[j] *np.sin(pi/2*i*j*1.0/self.Ng) for j in range(1,N_coeffs)]) \

--- a/examples/klayout_import/klayout_import.py
+++ b/examples/klayout_import/klayout_import.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import
 import emopt
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/periodic_Mie/periodic_Mie.py
+++ b/examples/periodic_Mie/periodic_Mie.py
@@ -8,6 +8,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 

--- a/examples/simple_waveguide/simple_waveguide.py
+++ b/examples/simple_waveguide/simple_waveguide.py
@@ -10,6 +10,7 @@ If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
 
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -69,7 +70,7 @@ sim.set_materials(eps, mu)
 Jz = np.zeros([M,N], dtype=np.complex128)
 Mx = np.zeros([M,N], dtype=np.complex128)
 My = np.zeros([M,N], dtype=np.complex128)
-Jz[M/2, N/2] = 1.0
+Jz[int(M/2), int(N/2)] = 1.0
 
 sim.set_sources((Jz, Mx, My))
 

--- a/examples/simple_waveguide/simple_waveguide_3D.py
+++ b/examples/simple_waveguide/simple_waveguide_3D.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 

--- a/examples/simple_waveguide/simple_waveguide_mode.py
+++ b/examples/simple_waveguide/simple_waveguide_mode.py
@@ -9,6 +9,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 

--- a/examples/simple_waveguide/simple_waveguide_mode_3D.py
+++ b/examples/simple_waveguide/simple_waveguide_mode_3D.py
@@ -20,6 +20,7 @@ terminates when this value drops below the specified rtol (which defaults to
 1e-6)
 """
 
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 

--- a/examples/simple_waveguide/simple_waveguide_mode_symmetric.py
+++ b/examples/simple_waveguide/simple_waveguide_mode_symmetric.py
@@ -10,6 +10,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 

--- a/examples/simple_waveguide/simple_waveguide_symmetric_x.py
+++ b/examples/simple_waveguide/simple_waveguide_symmetric_x.py
@@ -10,6 +10,7 @@ If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
 
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -71,7 +72,7 @@ sim.set_materials(eps, mu)
 Jz = np.zeros([M,N], dtype=np.complex128)
 Mx = np.zeros([M,N], dtype=np.complex128)
 My = np.zeros([M,N], dtype=np.complex128)
-Jz[M/2, 0] = 1.0
+Jz[int(M/2), 0] = 1.0
 
 sim.set_sources((Jz, Mx, My))
 

--- a/examples/simple_waveguide/simple_waveguide_symmetric_y.py
+++ b/examples/simple_waveguide/simple_waveguide_symmetric_y.py
@@ -10,6 +10,7 @@ If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
 
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -71,7 +72,7 @@ sim.set_materials(eps, mu)
 Jz = np.zeros([M,N], dtype=np.complex128)
 Mx = np.zeros([M,N], dtype=np.complex128)
 My = np.zeros([M,N], dtype=np.complex128)
-Jz[0, N/2] = 1.0
+Jz[0, int(N/2)] = 1.0
 
 sim.set_sources((Jz, Mx, My))
 

--- a/examples/waveguide_crossing/waveguide_crossing_TM.py
+++ b/examples/waveguide_crossing/waveguide_crossing_TM.py
@@ -35,6 +35,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL, RANK, run_on_master
 from emopt.adjoint_method import AdjointMethodPNF

--- a/examples/waveguide_modes/wg_modes_2D.py
+++ b/examples/waveguide_modes/wg_modes_2D.py
@@ -8,6 +8,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 

--- a/examples/waveguide_modes/wg_modes_2D_symmetry.py
+++ b/examples/waveguide_modes/wg_modes_2D_symmetry.py
@@ -8,6 +8,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 

--- a/examples/waveguide_modes/wg_modes_3D.py
+++ b/examples/waveguide_modes/wg_modes_3D.py
@@ -7,6 +7,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -64,7 +65,7 @@ Ex = modes.get_field_interp(0, 'Ex')
 if(NOT_PARALLEL):
     import matplotlib.pyplot as plt
 
-    print modes.neff[0]
+    print(modes.neff[0])
 
     eps_arr = eps.get_values_in(domain)
 

--- a/examples/waveguide_modes/wg_modes_3D_sym_0E.py
+++ b/examples/waveguide_modes/wg_modes_3D_sym_0E.py
@@ -7,6 +7,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -73,7 +74,7 @@ if(NOT_PARALLEL):
     eps_arr = np.concatenate([eps_arr[::-1,:], eps_arr], axis=0)
     H *= 2
 
-    print modes.neff[0]
+    print(modes.neff[0])
 
     #Ex = fields[0:M,:]
     vmin = np.min(np.abs(Ex))

--- a/examples/waveguide_modes/wg_modes_3D_sym_0H.py
+++ b/examples/waveguide_modes/wg_modes_3D_sym_0H.py
@@ -7,6 +7,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -73,7 +74,7 @@ if(NOT_PARALLEL):
     eps_arr = np.concatenate([eps_arr[::-1,:], eps_arr], axis=0)
     H *= 2
 
-    print modes.neff[0]
+    print(modes.neff[0])
 
     #Ex = fields[0:M,:]
     vmin = np.min(np.abs(Ex))

--- a/examples/waveguide_modes/wg_modes_3D_sym_E0.py
+++ b/examples/waveguide_modes/wg_modes_3D_sym_E0.py
@@ -7,6 +7,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -71,7 +72,7 @@ if(NOT_PARALLEL):
     eps_arr = np.concatenate([eps_arr[:,::-1], eps_arr], axis=1)
     W *= 2
 
-    print modes.neff[0]
+    print(modes.neff[0])
 
     #Ex = fields[0:M,:]
     vmin = np.min(np.abs(Ex))

--- a/examples/waveguide_modes/wg_modes_3D_sym_EH.py
+++ b/examples/waveguide_modes/wg_modes_3D_sym_EH.py
@@ -7,6 +7,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -75,7 +76,7 @@ if(NOT_PARALLEL):
     H *= 2
     W *= 2
 
-    print modes.neff[0]
+    print(modes.neff[0])
 
     #Ex = fields[0:M,:]
     vmin = np.min(np.abs(Ex))

--- a/examples/waveguide_modes/wg_modes_3D_sym_H0.py
+++ b/examples/waveguide_modes/wg_modes_3D_sym_H0.py
@@ -7,6 +7,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -72,7 +73,7 @@ if(NOT_PARALLEL):
     eps_arr = np.concatenate([eps_arr[:,::-1], eps_arr], axis=1)
     W *= 2
 
-    print modes.neff[0]
+    print(modes.neff[0])
 
     vmin = np.min(np.abs(Ex))
     vmax = np.max(np.abs(Ex))

--- a/examples/waveguide_modes/wg_modes_3D_sym_HE.py
+++ b/examples/waveguide_modes/wg_modes_3D_sym_HE.py
@@ -8,6 +8,7 @@ On most *nix-based machines, run the script with:
 If you wish to increase the number of cores that the example is executed on,
 change 8 to the desired number of cores.
 """
+from __future__ import division, print_function, absolute_import
 import emopt
 from emopt.misc import NOT_PARALLEL
 
@@ -76,7 +77,7 @@ if(NOT_PARALLEL):
     H *= 2
     W *= 2
 
-    print modes.neff[0]
+    print(modes.neff[0])
 
     vmin = np.min(np.abs(Ex))
     vmax = np.max(np.abs(Ex))

--- a/install.py
+++ b/install.py
@@ -30,6 +30,7 @@ of what went wrong. In most cases, the issue will be related to not having the
 appropriate prerequisite software packages installed.
 """
 
+from __future__ import division, print_function, absolute_import
 import os, sys, shutil, glob, requests
 from subprocess import call
 from argparse import ArgumentParser
@@ -86,7 +87,7 @@ def write_deps_file(home_dir, include_dir, install_dir):
     to install EMopt.
     """
     dep_fname = home_dir + '/' + emopt_dep_file
-    with open(dep_fname, 'wb') as fdep:
+    with open(dep_fname, 'w') as fdep:
         fdep.write('EIGEN_DIR=' + include_dir + '\n')
         fdep.write('BOOST_DIR=' + include_dir + '\n')
         fdep.write('PETSC_DIR=' + install_dir + '\n')

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import
 from setuptools import setup
 from setuptools.command.install import install as SetuptoolsInstall
 import subprocess, os, sys


### PR DESCRIPTION
In case you're interested...

This allows emopt to run in both python 2 and python 3. At least I think so ... I haven't yet thoroughly checked it by running all the examples. I will add more commits here if I find any other issues when I do that.

The specific changes are:

(1) added `from __future__ import division, print_function, absolute_import` to every python file, so that py2 and py3 have mostly the same behavior & bugs;
(2) `print` --> `print()`;
(3) `xrange` --> `range` [it has no performance impact in python 2 for small ranges];
(4) repair floor integer divisions to keep the same behavior (at least the ones I can find! Sorry if I introduced bugs by missing any!);
(5) implicit relative imports converted to explicit relative imports;
(6) `open(...'wb')` --> `open(...'w')` somewhere in install.py for py3 compatibility.

I did not edit the installation instructions. You just replace "python" with "python3" and "pip" with "pip3" etc. The only thing that wasn't obvious to me is that, while you can run `install.py` in python 3, you *do* still have to have python 2 installed on the system---one of the libraries needs access to python 2 in order to compile itself.