### PR TITLE
Quick fix for installation issues

### DIFF
--- a/emopt/fdtd.py
+++ b/emopt/fdtd.py
@@ -599,8 +599,8 @@ class FDTD(MaxwellSolver):
         self._w_pml_xmax = int(w_pml[1]/dx)
         self._w_pml_ymin = int(w_pml[2]/dy)
         self._w_pml_ymax = int(w_pml[3]/dy)
-        self._w_pml_zmin = int(w_pml[4]/dy)
-        self._w_pml_zmax = int(w_pml[5]/dy)
+        self._w_pml_zmin = int(w_pml[4]/dz)
+        self._w_pml_zmax = int(w_pml[5]/dz)
 
         self._w_pml = [self._w_pml_xmin*dx, self._w_pml_xmax*dx, \
                        self._w_pml_ymin*dy, self._w_pml_ymax*dy, \

--- a/install.py
+++ b/install.py
@@ -39,7 +39,7 @@ emopt_dep_file = ".emopt_deps"
 
 # Package Parameters
 EIGEN_VERSION = "3.3.7"
-BOOST_VERSION = "master"
+BOOST_VERSION = "1_73_0"
 PETSC_VERSION = "3.12.1"
 SLEPC_VERSION = "3.12.1"
 
@@ -120,9 +120,18 @@ def install_boost(include_dir):
     """
     print_message('Retrieving boost.geometry headers. This may take a few minutes...')
 
-    call(['git', 'clone', '--recursive', 'https://github.com/boostorg/boost.git'])
-    os.chdir('boost')
-    call(['git', 'checkout', BOOST_VERSION])
+    boost_url = "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0_rc1.tar.gz"
+
+    boost_fname = "boost_" + BOOST_VERSION + ".tar.gz"
+    r = requests.get(boost_url, allow_redirects=True)
+    with open(boost_fname, 'wb') as fsave:
+        fsave.write(r.content)
+
+    # unzip package
+    call(['tar', 'xvzf', boost_fname])
+
+    boost_folder = "boost_" + BOOST_VERSION
+    os.chdir(boost_folder)
     call(['./bootstrap.sh'])
     call(['./b2', 'headers'])
 
@@ -135,7 +144,7 @@ def install_boost(include_dir):
 
     print_message('Cleaning up boost directories')
     os.chdir('../')
-    shutil.rmtree('boost')
+    shutil.rmtree(boost_folder)
 
 def install_petsc(install_dir):
     """Compile and install PETSc."""
@@ -224,6 +233,7 @@ def install_deps():
         install_dir = home_dir + '/.emopt/'
     else:
         install_dir = args.prefix
+        print(install_dir)
 
     if(not os.path.exists(install_dir)):
         os.makedirs(install_dir)

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(name='emopt',
       packages=['emopt'],
       package_data={'emopt':['*.so', '*.csv', 'data/*']},
       cmdclass={'install':MakeInstall},
-      install_requires=['numpy', 'scipy', 'mpi4py', 'petsc4py', 'slepc4py'],
+      install_requires=['numpy', 'scipy', 'mpi4py', 'petsc4py==3.12.0', 'slepc4py==3.12.0'],
       zip_safe=False)


### PR DESCRIPTION
1. Fix of install.py to correct a recent update of the boost geometry repo which breaks c++11 compilation. This hard-codes a direct download to boost version 1.73.0. 
2. Hard-coded the versions of petsc4py and slepc4py that are retrieved in setup.py to fix an incompatibility with the versions of petsc and slepc that were installed from source in install.py. An alternate installation scheme might be preferable, but works for now. 
3. Minor bug fix in emopt/fdtd.py to correct the w_pml setter.

Tested on CentOS 7 with Python 2.7 and Python 3.8